### PR TITLE
adding git to the mix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb
     tee /etc/apt/sources.list.d/azure-cli.list
 RUN apt-get update
 RUN apt-get install azure-cli
+RUN apt-get update
+RUN apt-get install git-core
 COPY --from=terraform /terraform /usr/local/bin/terraform


### PR DESCRIPTION
trying to fix errors we are getting on remote modules in terraform:

```
Error: Failed to download module

Could not download module "ModuleName" (api.tf:1) source code from
"github.com/[ORGNAME]/tfmodules/[ModuleName]": error downloading
'https://github.com/[ORGNAME]/tfmodules.git': git must be available and on
the PATH
```

I going off this example https://www.liquidweb.com/kb/install-git-ubuntu-16-04-lts/ 